### PR TITLE
Various fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ More information can be found [here](docs/contributing.md).
 
 ## License
 Nexus Unit Testing is available under the terms of the Apache 
-Liscence 2.0. See [LICENSE](LICENSE) for details.
+Licence 2.0. See [LICENSE](LICENSE) for details.

--- a/src/NexusUnitTestingProject.lua
+++ b/src/NexusUnitTestingProject.lua
@@ -18,7 +18,8 @@ NexusUnitTestingProject.TestState.Failed = "FAILED"
 NexusUnitTestingProject.TestState.Skipped = "SKIPPED"
 
 
-
+NexusUnitTestingProject.BasePrint = print
+NexusUnitTestingProject.BaseWarn = warn
 
 --Return the project.
 return NexusUnitTestingProject

--- a/src/Runtime/ModuleUnitTest.lua
+++ b/src/Runtime/ModuleUnitTest.lua
@@ -42,11 +42,11 @@ function ModuleUnitTest:Run()
 		return self.Sandbox:RequireModule(Module,EnvironmentOverrides)
 	end
 	EnvironmentOverrides["print"] = function(...)
-		print(...)
+		NexusUnitTesting.BasePrint(...)
 		self:OutputMessage(Enum.MessageType.MessageOutput,...)
 	end
 	EnvironmentOverrides["warn"] = function(...)
-		warn(...)
+		NexusUnitTesting.BaseWarn(...)
 		self:OutputMessage(Enum.MessageType.MessageWarning,...)
 	end
 	

--- a/src/Runtime/ModuleUnitTest.lua
+++ b/src/Runtime/ModuleUnitTest.lua
@@ -42,9 +42,11 @@ function ModuleUnitTest:Run()
 		return self.Sandbox:RequireModule(Module,EnvironmentOverrides)
 	end
 	EnvironmentOverrides["print"] = function(...)
+		print(...)
 		self:OutputMessage(Enum.MessageType.MessageOutput,...)
 	end
 	EnvironmentOverrides["warn"] = function(...)
+		warn(...)
 		self:OutputMessage(Enum.MessageType.MessageWarning,...)
 	end
 	

--- a/src/Runtime/TestFinder.lua
+++ b/src/Runtime/TestFinder.lua
@@ -75,7 +75,7 @@ function Runner.GetTests(Container)
 	
 	--Get all the tests in the game.
 	local Tests = {}
-	for _,Module in pairs(Container:GetDescendants()) do
+	for _,Module in ipairs(Container:GetDescendants()) do
 		pcall(function()
 			if Module:IsA("ModuleScript") and (Module.Name:match("%.spec$") or Runner.ScriptContainsTests(Module.Source)) then
 				table.insert(Tests,ModuleUnitTest.new(Module))

--- a/src/UnitTest/UnitTest.lua
+++ b/src/UnitTest/UnitTest.lua
@@ -85,7 +85,7 @@ function UnitTest:AddTestEZOverrides()
 	local Environment = TestPlanner.createEnvironment(PlanBuilder)
 	
 	--Add the methods.
-	for Name,Value in pairs(Environment) do
+	for Name,Value in ipairs(Environment) do
 		self:SetEnvironmentOverride(Name,Value)
 	end
 end
@@ -231,7 +231,7 @@ function UnitTest:BaseRunTest()
 			end
 			
 			--Visit the child nodes.
-			for _,ChildNode in pairs(Node.children) do
+			for _,ChildNode in ipairs(Node.children) do
 				VisitChildNode(ChildNode,NewTest)
 			end
 			
@@ -239,14 +239,14 @@ function UnitTest:BaseRunTest()
 			NewTest:UpdateCombinedState()
 			
 			--Output the error(s).
-			for _,Error in pairs(Node.errors) do
+			for _,Error in ipairs(Node.errors) do
 				self:OutputMessage(Enum.MessageType.MessageError,string.split(Error,"\n",1)[1])
 				self:OutputMessage(Enum.MessageType.MessageInfo,Error)
 			end
 		end
 		
 		--Visit the children.
-		for _,ChildNode in pairs(TestEZResults.children) do
+		for _,ChildNode in ipairs(TestEZResults.children) do
 			VisitChildNode(ChildNode,self)
 		end
 	end
@@ -335,7 +335,7 @@ function UnitTest:RunSubtests()
 		self.CombinedState = NexusUnitTesting.TestState.InProgress
 		
 		--Run the subtests to get the tests.
-		for _,Test in pairs(self.SubTests) do
+		for _,Test in ipairs(self.SubTests) do
 			if Test.State == NexusUnitTesting.TestState.NotRun then
 				self.CurSubTest = Test
 				Test:RunTest()
@@ -344,7 +344,7 @@ function UnitTest:RunSubtests()
 		end
 
 		--Run the subtests' subtests.
-		for _,Test in pairs(self.SubTests) do
+		for _,Test in ipairs(self.SubTests) do
 			self.CurSubTest = Test
 			Test:RunSubtests()
 		end
@@ -400,7 +400,7 @@ function UnitTest:UpdateCombinedState()
 	local CombinedState = self.State
 	
 	--Set the state based on the tests.
-	for _,Test in pairs(self.SubTests) do
+	for _,Test in ipairs(self.SubTests) do
 		local TestState = Test.CombinedState
 		if UNIT_TEST_STATE_PRIORITY[TestState] > UNIT_TEST_STATE_PRIORITY[CombinedState] then
 			CombinedState = TestState
@@ -496,7 +496,7 @@ function UnitTest:AssertEquals(ExpectedObject,ActualObject,Message)
 	if not Message then
 		Message = "Two objects aren't equal."
 	end
-	local Comparison = "\n\tObject 1: "..tostring(ExpectedObject).."\n\tObject 2: "..tostring(ActualObject)
+	local Comparison = "\n\tExpected: "..tostring(ExpectedObject).."\n\tActual: "..tostring(ActualObject)
 	Message = Message..Comparison
 	
 	--Set up the function.
@@ -523,7 +523,7 @@ function UnitTest:AssertNotEquals(ExpectedObject,ActualObject,Message)
 	if not Message then
 		Message = "Two objects are equal."
 	end
-	local Comparison = "\n\tObject 1: "..tostring(ExpectedObject).."\n\tObject 2: "..tostring(ActualObject)
+	local Comparison = "\n\tExpected: "..tostring(ExpectedObject).."\n\tActual: "..tostring(ActualObject)
 	Message = Message..Comparison
 	
 	--Set up the function.
@@ -550,7 +550,7 @@ function UnitTest:AssertSame(ExpectedObject,ActualObject,Message)
 	if not Message then
 		Message = "Two objects aren't the same."
 	end
-	Message = Message.."\n\tObject 1: "..tostring(ExpectedObject).."\n\tObject 2: "..tostring(ActualObject)
+	Message = Message.."\n\tExpected: "..tostring(ExpectedObject).."\n\tActual: "..tostring(ActualObject)
 	
 	--Set up the function.
 	local function Assert()
@@ -570,7 +570,7 @@ function UnitTest:AssertNotSame(ExpectedObject,ActualObject,Message)
 	if not Message then
 		Message = "Two objects are the same."
 	end
-	Message = Message.."\n\tObject 1: "..tostring(ExpectedObject).."\n\tObject 2: "..tostring(ActualObject)
+	Message = Message.."\n\tExpected: "..tostring(ExpectedObject).."\n\tActual: "..tostring(ActualObject)
 	
 	--Set up the function.
 	local function Assert()
@@ -596,7 +596,7 @@ function UnitTest:AssertClose(ExpectedObject,ActualObject,Epsilon,Message)
 	if not Message then
 		Message = "Two objects aren't close."
 	end
-	local Comparison = "\n\tObject 1: "..tostring(ExpectedObject).."\n\tObject 2: "..tostring(ActualObject)
+	local Comparison = "\n\tExpected: "..tostring(ExpectedObject).."\n\tActual: "..tostring(ActualObject)
 	Message = Message..Comparison
 	
 	--Set up the function.
@@ -634,7 +634,7 @@ function UnitTest:AssertNotClose(ExpectedObject,ActualObject,Epsilon,Message)
 	if not Message then
 		Message = "Two objects aren't close."
 	end
-	local Comparison = "\n\tObject 1: "..tostring(ExpectedObject).."\n\tObject 2: "..tostring(ActualObject)
+	local Comparison = "\n\tExpected: "..tostring(ExpectedObject).."\n\tActual: "..tostring(ActualObject)
 	Message = Message..Comparison
 	
 	--Set up the function.

--- a/src/UnitTest/UnitTest.lua
+++ b/src/UnitTest/UnitTest.lua
@@ -334,6 +334,7 @@ function UnitTest:RunSubtests()
 			if Test.State == NexusUnitTesting.TestState.NotRun then
 				coroutine.wrap(function()
 					Test:RunTest()
+					self:UpdateCombinedState()
 				end)()
 			end
 		end

--- a/src/UnitTest/UnitTest.lua
+++ b/src/UnitTest/UnitTest.lua
@@ -332,7 +332,9 @@ function UnitTest:RunSubtests()
 		--Run the subtests to get the tests.
 		for _,Test in pairs(self.SubTests) do
 			if Test.State == NexusUnitTesting.TestState.NotRun then
-				Test:RunTest()
+				coroutine.wrap(function()
+					Test:RunTest()
+				end)()
 			end
 		end
 		

--- a/src/UnitTest/UnitTest.lua
+++ b/src/UnitTest/UnitTest.lua
@@ -85,7 +85,7 @@ function UnitTest:AddTestEZOverrides()
 	local Environment = TestPlanner.createEnvironment(PlanBuilder)
 	
 	--Add the methods.
-	for Name,Value in ipairs(Environment) do
+	for Name,Value in pairs(Environment) do
 		self:SetEnvironmentOverride(Name,Value)
 	end
 end
@@ -491,7 +491,7 @@ Asserts that two objects are equal. Special cases are handles for
 objects like arrays that may have the same elements. Not intended
 to be used on Roblox Instances.
 --]]
-function UnitTest:AssertEquals(ExpectedObject,ActualObject,Message)
+function UnitTest:AssertEquals(ActualObject,ExpectedObject,Message)
 	--Set up the message.
 	if not Message then
 		Message = "Two objects aren't equal."
@@ -518,7 +518,7 @@ end
 Asserts that two objects aren't equal. Special cases are handles for
 objects like arrays that may have the same elements.
 --]]
-function UnitTest:AssertNotEquals(ExpectedObject,ActualObject,Message)
+function UnitTest:AssertNotEquals(ActualObject,ExpectedObject,Message)
 	--Set up the message.
 	if not Message then
 		Message = "Two objects are equal."
@@ -545,7 +545,7 @@ end
 Asserts that two objects are the same. This is mainly used for testing
 if a new array or instance isn't created.
 --]]
-function UnitTest:AssertSame(ExpectedObject,ActualObject,Message)
+function UnitTest:AssertSame(ActualObject,ExpectedObject,Message)
 	--Set up the message.
 	if not Message then
 		Message = "Two objects aren't the same."
@@ -565,7 +565,7 @@ end
 Asserts that two objects aren't the same. This is mainly used for testing
 if a new array or instance isn't created.
 --]]
-function UnitTest:AssertNotSame(ExpectedObject,ActualObject,Message)
+function UnitTest:AssertNotSame(ActualObject,ExpectedObject,Message)
 	--Set up the message.
 	if not Message then
 		Message = "Two objects are the same."
@@ -585,7 +585,7 @@ end
 Asserts that two objects are within a given Epsilon of each other. If
 the message is used in place of the Epsilon, 0.001 will be used.
 --]]
-function UnitTest:AssertClose(ExpectedObject,ActualObject,Epsilon,Message)
+function UnitTest:AssertClose(ActualObject,ExpectedObject,Epsilon,Message)
 	--Set the message as the epsilon if needed.
 	if type(Epsilon) == "string" and Message == nil then
 		Message = Epsilon
@@ -623,7 +623,7 @@ end
 Asserts that two objects aren't within a given Epsilon of each other. If
 the message is used in place of the Epsilon, 0.001 will be used.
 --]]
-function UnitTest:AssertNotClose(ExpectedObject,ActualObject,Epsilon,Message)
+function UnitTest:AssertNotClose(ActualObject,ExpectedObject,Epsilon,Message)
 	--Set the message as the epsilon if needed.
 	if type(Epsilon) == "string" and Message == nil then
 		Message = Epsilon

--- a/src/init.lua
+++ b/src/init.lua
@@ -40,13 +40,13 @@ function NexusUnitTesting.RunTests(Container)
 		end
 		
 		--Run the subtests.
-		for _,SubTest in pairs(Test.SubTests) do
+		for _,SubTest in ipairs(Test.SubTests) do
 			RunTest(SubTest,TestName.." > ")
 		end
 	end
 	
 	--Run the tests.
-	for _,Test in pairs(Tests) do
+	for _,Test in ipairs(Tests) do
 		RunTest(Test,"")
 	end
 	
@@ -54,13 +54,13 @@ function NexusUnitTesting.RunTests(Container)
 	print("")
 	if #SkippedTests ~= 0 then
 		print("Skipped tests:")
-		for _,TestName in pairs(SkippedTests) do
+		for _,TestName in ipairs(SkippedTests) do
 			print("\t"..TestName)
 		end
 	end
 	if #FailedTests ~= 0 then
 		print("Failed tests:")
-		for _,TestName in pairs(FailedTests) do
+		for _,TestName in ipairs(FailedTests) do
 			print("\t"..TestName)
 		end
 	end


### PR DESCRIPTION
Change overview:

- print/warn now also sent to Roblox's Output Window so you can see debug statements/warnings easily (the same as errors)
- pairs -> ipairs when appropriate (pairs takes ~22% more time)
- Display "Expected:"/"Actual:" instead of "Object 1:"/"Object 2:". Parameter names were in the wrong order compared to how they were being used, so that was fixed too.
- Subtest print/warn statements are now correctly sent to the subtest's output rather than the parent test
- RegisterUnitTest uses SetRun instead of SetSetup for "backwards compatibility"
- A few spelling mistakes fixed

Note:
- Despite the description of the first commit, subtests no longer run asynchronously