### PR TITLE
Fixed Cyclic Checking

### DIFF
--- a/src/UnitTest/AssertionHelper/Equals.lua
+++ b/src/UnitTest/AssertionHelper/Equals.lua
@@ -37,25 +37,31 @@ local function Equals(Object1,Object2,CheckedValues)
 	end
 	
 	--If it is a table, check the keys and values being the same.
-	if type(Object1) == "table" and type(Object2) == "table" and Object1 ~= Object2 then
-		--Check the tables.
-		for Key,Value in pairs(Object1) do
-			if PerformCyclicCheck(Value,Object2[Key]) then
-				if not Equals(Value,Object2[Key],CheckedValues) then
-					return false
+	if type(Object1) == "table" and type(Object2) == "table" then
+		-- Check the tables.
+		if Object1 ~= Object2 then
+			for Key, Value in pairs(Object1) do
+				if PerformCyclicCheck(Value, Object2[Key]) then
+					if not Equals(Value, Object2[Key], CheckedValues) then
+						return false
+					end
+				end
+			end
+
+			for Key, Value in pairs(Object2) do
+				if PerformCyclicCheck(Value, Object1[Key]) then
+					if not Equals(Value, Object1[Key], CheckedValues) then
+						return false
+					end
 				end
 			end
 		end
 		
-		for Key,Value in pairs(Object2) do
-			if PerformCyclicCheck(Value,Object1[Key]) then
-				if not Equals(Value,Object1[Key],CheckedValues) then
-					return false
-				end
-			end
-		end
-		
-		--Return true (all equal).
+		-- Clear the checked flag for the values
+		CheckedValues[Object1] = nil
+		CheckedValues[Object2] = nil
+
+		-- Return true (all equal).
 		return true
 	end
 	

--- a/src/UnitTest/AssertionHelper/Equals.lua
+++ b/src/UnitTest/AssertionHelper/Equals.lua
@@ -4,17 +4,15 @@ TheNexusAvenger
 Helper function for determining if two userdata objects are equal.
 --]]
 
-
-
 --[[
 Returns if two user data are equal.
 --]]
 local function Equals(Object1,Object2,CheckedValues)
 	--Create the checked values table if it doesn't exist.
 	if not CheckedValues then
-		CheckedValues = {}
+		CheckedValues = { {}, {} }
 	end
-	
+
 	--[[
 	Performs a cyclic check and returns
 	if the equals method should continue.
@@ -24,18 +22,18 @@ local function Equals(Object1,Object2,CheckedValues)
 		if type(Value1) ~= "table" or type(Value2) ~= "table" then
 			return true
 		end
-		
+
 		--Return false if either value was already checked.
-		if CheckedValues[Value1] or CheckedValues[Value2] then
+		if CheckedValues[1][Value1] or CheckedValues[2][Value2] then
 			return false
 		end
-		
+
 		--Store the values and return true (continue).
-		CheckedValues[Value1] = true
-		CheckedValues[Value2] = true
+		CheckedValues[1][Value1] = true
+		CheckedValues[2][Value2] = true
 		return true
 	end
-	
+
 	--If it is a table, check the keys and values being the same.
 	if type(Object1) == "table" and type(Object2) == "table" then
 		-- Check the tables.
@@ -56,19 +54,17 @@ local function Equals(Object1,Object2,CheckedValues)
 				end
 			end
 		end
-		
+
 		-- Clear the checked flag for the values
-		CheckedValues[Object1] = nil
-		CheckedValues[Object2] = nil
+		CheckedValues[1][Object1] = nil
+		CheckedValues[2][Object2] = nil
 
 		-- Return true (all equal).
 		return true
 	end
-	
+
 	--Return equality (base case)
 	return Object1 == Object2
 end
-
-
 
 return Equals

--- a/test/UnitTest/AssertionHelper/EqualsTests.lua
+++ b/test/UnitTest/AssertionHelper/EqualsTests.lua
@@ -72,12 +72,12 @@ end)
 Tests the Equals function with relative cyclic values.
 --]]
 NexusUnitTesting:RegisterUnitTest("EqualsRelativeCyclic",function(UnitTest)
-	local Table1 = { 0, { 1, nil } } 
-	Table1[2][2] = Table1 -- Expands: { 0, { 1, |{0,{1,...}}| } }
-	local Table2 = { 0, { 1, nil } }
-	Table2[2][2] = Table2-- Expands: { 0, { 1, |{0,{1,...}}| } }
-	local Table3 = { 0, { 1, nil } }
-	Table3[2][2] = Table3[2] -- Expands: { 0, { 1, |{1,...}| } }
+	local Table1 = { 0, { 0, nil } }
+	Table1[2][2] = Table1 -- Expands: { 0, { 0, |{0,{0,...}}| } }
+	local Table2 = { 0, { 0, nil } }
+	Table2[2][2] = Table2 -- Expands: { 0, { 0, |{0,{0,...}}| } }
+	local Table3 = { 0, { 0, nil } }
+	Table3[2][2] = Table3[2] -- Expands: { 0, { 0, |{0,...}| } }
 
 	UnitTest:AssertTrue(Equals(Table1,Table2),"Tables with same values are different")
 	UnitTest:AssertFalse(Equals(Table1,Table3),"Tables with different values are equal")

--- a/test/UnitTest/AssertionHelper/EqualsTests.lua
+++ b/test/UnitTest/AssertionHelper/EqualsTests.lua
@@ -5,11 +5,7 @@ Tests the Equals helper function.
 --]]
 
 local NexusUnitTesting = require("NexusUnitTesting")
-
-local NexusUnitTestingProject = require(game:GetService("ReplicatedStorage"):WaitForChild("NexusUnitTesting"):WaitForChild("NexusUnitTestingProject"))
-local Equals = NexusUnitTestingProject:GetResource("UnitTest.AssertionHelper.Equals")
-
-
+local Equals = require(script.Parent)
 
 --[[
 Tests the Equals function with Roblox objects.
@@ -27,7 +23,7 @@ NexusUnitTesting:RegisterUnitTest("EqualsLists",function(UnitTest)
 	local List1 = {1,1,2,3,5,8,13}
 	local List2 = {1,1,2,3,5,8,13}
 	local List3 = {1,1,2,3,5,8}
-	
+
 	UnitTest:AssertFalse(List1 == List2,"Lists have the same memory reference.")
 	UnitTest:AssertTrue(Equals(List1,List2),"Lists with same values are different")
 	UnitTest:AssertFalse(Equals(List1,List3),"Lists with missing values are equal")
@@ -40,7 +36,7 @@ NexusUnitTesting:RegisterUnitTest("EqualsMixedTables",function(UnitTest)
 	local Table1 = {1,1,2,3,Value1=5,8,Value2=13}
 	local Table2 = {1,1,2,3,Value1=5,8,Value2=13}
 	local Table3 = {1,1,Value1=2,3,5,8,Value2=13}
-	
+
 	UnitTest:AssertTrue(Equals(Table1,Table2),"Tables with same values are different")
 	UnitTest:AssertFalse(Equals(Table1,Table3),"Tables with missing values are equal")
 end)
@@ -52,7 +48,7 @@ NexusUnitTesting:RegisterUnitTest("EqualsDeepTables",function(UnitTest)
 	local Table1 = {1,1,{2,3,Value3=5,{1,2}},Value1=5,8,Value2=13}
 	local Table2 = {1,1,{2,3,Value3=5,{1,2}},Value1=5,8,Value2=13}
 	local Table3 = {1,1,{2,3,Value3=5,{1}},Value1=5,8,Value2=13}
-	
+
 	UnitTest:AssertTrue(Equals(Table1,Table2),"Tables with same values are different")
 	UnitTest:AssertFalse(Equals(Table1,Table3),"Tables with missing values are equal")
 end)
@@ -67,9 +63,24 @@ NexusUnitTesting:RegisterUnitTest("EqualsCyclicTables",function(UnitTest)
 	Table2.Value4 = Table2
 	local Table3 = {1,1,{2,3,Value3=5,{1}},Value1=5,8,Value2=13}
 	Table3.Value4 = Table3
-	
+
 	UnitTest:AssertTrue(Equals(Table1,Table2),"Tables with same values are different")
 	UnitTest:AssertFalse(Equals(Table1,Table3),"Tables with missing values are equal")
+end)
+
+--[[
+Tests the Equals function with relative cyclic values.
+--]]
+NexusUnitTesting:RegisterUnitTest("EqualsRelativeCyclic",function(UnitTest)
+	local Table1 = { 0, { 1, nil } } 
+	Table1[2][2] = Table1 -- Expands: { 0, { 1, |{0,{1,...}}| } }
+	local Table2 = { 0, { 1, nil } }
+	Table2[2][2] = Table2-- Expands: { 0, { 1, |{0,{1,...}}| } }
+	local Table3 = { 0, { 1, nil } }
+	Table3[2][2] = Table3[2] -- Expands: { 0, { 1, |{1,...}| } }
+
+	UnitTest:AssertTrue(Equals(Table1,Table2),"Tables with same values are different")
+	UnitTest:AssertFalse(Equals(Table1,Table3),"Tables with different values are equal")
 end)
 
 --[[
@@ -78,8 +89,22 @@ Tests the Equals function with already checked values.
 NexusUnitTesting:RegisterUnitTest("EqualsCheckedTables",function(UnitTest)
 	local Table0 = { 0 }
 	local Table1 = { { 0 }, { 0 } }
-	local Table2 = { Table0, Table0 }
+	local Table2 = { Table0, Table0 } -- Expands: { { 0 }, { 0 } }
 	local Table3 = { { 0 }, { 1 } }
+
+	UnitTest:AssertTrue(Equals(Table1,Table2),"Tables with same values are different")
+	UnitTest:AssertFalse(Equals(Table1,Table3),"Tables with different values are equal")
+	UnitTest:AssertFalse(Equals(Table2,Table3),"Tables with different values are equal")
+end)
+
+--[[
+Tests the Equals function with cross checked values.
+--]]
+NexusUnitTesting:RegisterUnitTest("EqualsCrossChecked",function(UnitTest)
+	local Table0 = { 0, { 0 } }
+	local Table1 = { { 0, { 0 } } }
+	local Table2 = { Table0 } -- Expands: { { 0, { 0 } } }
+	local Table3 = { { 0, Table0 } } -- Expands: { { 0, { 0, { 0 } } } }
 
 	UnitTest:AssertTrue(Equals(Table1,Table2),"Tables with same values are different")
 	UnitTest:AssertFalse(Equals(Table1,Table3),"Tables with different values are equal")

--- a/test/UnitTest/AssertionHelper/EqualsTests.lua
+++ b/test/UnitTest/AssertionHelper/EqualsTests.lua
@@ -72,6 +72,18 @@ NexusUnitTesting:RegisterUnitTest("EqualsCyclicTables",function(UnitTest)
 	UnitTest:AssertFalse(Equals(Table1,Table3),"Tables with missing values are equal")
 end)
 
+--[[
+Tests the Equals function with already checked values.
+--]]
+NexusUnitTesting:RegisterUnitTest("EqualsCheckedTables",function(UnitTest)
+	local Table0 = { 0 }
+	local Table1 = { { 0 }, { 0 } }
+	local Table2 = { Table0, Table0 }
+	local Table3 = { { 0 }, { 1 } }
 
+	UnitTest:AssertTrue(Equals(Table1,Table2),"Tables with same values are different")
+	UnitTest:AssertFalse(Equals(Table1,Table3),"Tables with different values are equal")
+	UnitTest:AssertFalse(Equals(Table2,Table3),"Tables with different values are equal")
+end)
 
 return true


### PR DESCRIPTION
Becuase of `if CheckedValues[Value1] or CheckedValues[Value2] then` within `PerformCyclicCheck` there are cases when Equals will return true for tables which are different. The following test will fail because true is returned for `Equals(Table2,Table3)`:

```lua
NexusUnitTesting:RegisterUnitTest("EqualsCheckedTables",function(UnitTest)
	local Table0 = { 0 }
	local Table1 = { { 0 }, { 0 } }
	local Table2 = { Table0, Table0 }
	local Table3 = { { 0 }, { 1 } }
	
	UnitTest:AssertTrue(Equals(Table1,Table2),"Tables with same values are different")
	UnitTest:AssertFalse(Equals(Table1,Table3),"Tables with different values are equal")
	UnitTest:AssertFalse(Equals(Table2,Table3),"Tables with different values are equal")
end)
```

Implemented Fix: Set `CheckedValues` of each object to nil after each table has been walked as a new encounter would not be cyclic.